### PR TITLE
Link to docs as source of truth, document queryPresentations gap

### DIFF
--- a/plugins/omni-analytics/skills/omni-content-builder/SKILL.md
+++ b/plugins/omni-analytics/skills/omni-content-builder/SKILL.md
@@ -7,6 +7,9 @@ description: Create, update, and manage Omni Analytics documents and dashboards 
 
 Create, update, and manage Omni documents and dashboards programmatically via the REST API — document lifecycle, workbook models, filters, and dashboard content.
 
+> **Always check the official Omni docs first:** https://docs.omni.co/llms.txt
+> This skill covers patterns not fully documented elsewhere — especially the `queryPresentations` format for creating dashboards with tiles.
+
 > **Tip**: Use `omni-model-explorer` to understand available fields and `omni-content-explorer` to find existing dashboards to modify or learn from.
 
 ## Prerequisites
@@ -43,7 +46,9 @@ Returns the new document's `identifier`, `workbookId`, and `dashboardId`.
 
 ### Create Document with Queries and Visualizations
 
-Use `queryPresentations` to create a document pre-populated with query tabs and visualization configurations:
+Use `queryPresentations` to create a document pre-populated with query tabs and visualization configurations.
+
+> **Doc gap**: The [create-document API docs](https://docs.omni.co/api/documents/create-document.md) mention queryPresentations but don't show the complete structure. This section documents the full format.
 
 ```bash
 curl -L -X POST "$OMNI_BASE_URL/api/v1/documents" \
@@ -103,6 +108,14 @@ curl -L -X POST "$OMNI_BASE_URL/api/v1/documents" \
   }'
 ```
 
+#### Key Parameters (not fully documented elsewhere)
+
+| Parameter | Notes |
+|-----------|-------|
+| `modelId` | Use the **base shared model UUID**, not a branchId. Get this from the List Models API. |
+| Field format | `table.field_name` or `table.field_name[week\|month\|day\|quarter\|year]` for time granularity |
+| `sorts` | `column_name` must match the **exact field string** (e.g., `"order_items.created_at[month]"`), with `sort_descending` boolean |
+
 #### Query Object Reference
 
 The `query` object within each query presentation uses the same structure as the [Query API](https://docs.omni.co/api/queries.md):
@@ -121,18 +134,25 @@ The `query` object within each query presentation uses the same structure as the
 
 #### visConfig Object
 
-The `visConfig` object controls how each query is visualized. The `chartType` field sets the visualization type. Common values include:
+The `visConfig` object controls how each query is visualized. The `chartType` field sets the visualization type.
+
+**Core chartType values** (most commonly used):
 
 | chartType | Visualization |
 |-----------|--------------|
+| `kpi` | KPI / single value |
 | `lineColor` | Line chart |
 | `barColor` | Bar chart |
-| `stackedBarColor` | Stacked bar chart |
 | `areaColor` | Area chart |
-| `scatter` | Scatter plot |
 | `pie` | Pie / donut chart |
-| `kpi` | KPI / single value |
 | `table` | Data table |
+
+**Additional chartType values**:
+
+| chartType | Visualization |
+|-----------|--------------|
+| `stackedBarColor` | Stacked bar chart |
+| `scatter` | Scatter plot |
 | `heatmap` | Heatmap |
 | `map` | Map visualization |
 

--- a/plugins/omni-analytics/skills/omni-model-builder/SKILL.md
+++ b/plugins/omni-analytics/skills/omni-model-builder/SKILL.md
@@ -7,6 +7,9 @@ description: Create and edit Omni Analytics semantic model definitions — views
 
 Create and modify Omni's semantic model through the YAML API — views, topics, dimensions, measures, relationships, and query views.
 
+> **Always check the official Omni docs first:** https://docs.omni.co/llms.txt
+> This skill covers patterns and workflows. For complete YAML syntax and parameters, the docs are the source of truth.
+
 > **Tip**: Always use `omni-model-explorer` first to understand the existing model.
 
 ## Prerequisites
@@ -101,7 +104,7 @@ measures:
 
 ### Measure Parameters
 
-Aggregate types: `count`, `count_distinct`, `sum`, `average`, `min`, `max`, `median`
+See [Measures documentation](https://docs.omni.co/modeling/measures/index.md) for complete syntax and [aggregate_type reference](https://docs.omni.co/modeling/measures/parameters/aggregate-type.md) for all 13 valid values.
 
 Measure filters restrict rows before aggregation:
 
@@ -124,29 +127,15 @@ Filter conditions: `is`, `is_not`, `greater_than`, `less_than`, `contains`, `sta
 
 ## Writing Topics
 
-```yaml
-base_view: order_items
-label: Order Transactions
-description: Line-item order data for revenue and product analysis
+See [Topics setup](https://docs.omni.co/modeling/topics/setup.md) for complete YAML examples with joins, fields, and ai_context, and [Topic parameters](https://docs.omni.co/modeling/topics/parameters.md) for all available options.
 
-ai_context: |
-  Map "revenue" → total_revenue. Map "orders" → count.
-  Status values: complete, pending, cancelled, returned.
-  Only "complete" orders for revenue unless specified otherwise.
-
-joins:
-  users: {}
-  inventory_items:
-    products: {}
-
-default_filters:
-  order_items.status:
-    not: [Returned, Cancelled]
-```
-
-Nested joins indicate join chains. Use `always_where_sql` for non-removable filters.
-
-Field curation: `fields: [order_items.*, users.name, -users.internal_id]`
+Key topic elements:
+- `base_view` — the primary view for this topic
+- `joins` — nested structure for join chains (e.g., `users: {}` or `inventory_items: { products: {} }`)
+- `ai_context` — guides Blobby's field mapping (e.g., "Map 'revenue' → total_revenue")
+- `default_filters` — applied to all queries unless removed
+- `always_where_sql` — non-removable filters
+- `fields` — field curation: `[order_items.*, users.name, -users.internal_id]`
 
 ## Writing Relationships
 

--- a/plugins/omni-analytics/skills/omni-query/SKILL.md
+++ b/plugins/omni-analytics/skills/omni-query/SKILL.md
@@ -7,6 +7,9 @@ description: Run queries against Omni Analytics' semantic layer using the REST A
 
 Run queries against Omni's semantic layer via the REST API. Omni translates field selections into optimized SQL — you specify what you want (dimensions, measures, filters), not how to get it.
 
+> **Always check the official Omni docs first:** https://docs.omni.co/llms.txt
+> See the [Query API docs](https://docs.omni.co/api/queries.md) for complete parameter reference.
+
 > **Tip**: Use `omni-model-explorer` first if you don't know the available topics and fields.
 
 ## Prerequisites


### PR DESCRIPTION
@jacksweeney5 this is what cursor came up with for changes, based on my experience using it today. Would love to get your thoughts. The two main things are: pushing it to check the docs where a more exhaustive explanation is available there, and explicitly calling out where there are docs gaps that the skill fills