### PR TITLE
chore: deprecate repo in favor of exploreomni/omni-agent-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,43 @@
+> [!CAUTION]
+> **This repository is deprecated and no longer maintained.**
+> All skills have been consolidated into [`exploreomni/omni-agent-skills`](https://github.com/exploreomni/omni-agent-skills), which supports Claude Code, Cursor, OpenAI Codex, Snowflake Cortex Code, GitHub Copilot, Gemini CLI, and other skills.sh-compatible agents.
+
+## Migrating
+
+Uninstall the old plugin and install the new one:
+
+```bash
+# Remove the old marketplace and plugin
+/plugin uninstall omni-analytics@omni-analytics
+/plugin marketplace remove omni-claude-skills
+
+# Install the new unified plugin
+/plugin marketplace add exploreomni/omni-agent-skills
+/plugin install omni-analytics@omni-analytics
+```
+
+If you use team deployment via `.claude/settings.json`, update the marketplace source:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "omni-analytics": {
+      "source": {
+        "source": "github",
+        "repo": "exploreomni/omni-agent-skills"
+      }
+    }
+  },
+  "enabledPlugins": ["omni-analytics@omni-analytics"]
+}
+```
+
+---
+
+_The original README is preserved below for reference._
+
+---
+
 # Omni Analytics Plugin for Claude Code
 
 A Claude Code plugin that helps analytics engineers and data teams work with [Omni Analytics](https://omni.co) programmatically through Omni's REST APIs.
@@ -31,7 +71,7 @@ Enable plugin auto-updates:
   2. Go to Marketplaces                                                                                                                                                             
   3. Select the marketplace → Enable auto-update
 
-Alternatively, update the plugin manually from the /plugin menu or reinstall it to ensure you’re using the latest version.
+Alternatively, update the plugin manually from the /plugin menu or reinstall it to ensure you're using the latest version.
 
 ## Setup
 


### PR DESCRIPTION
## Summary

- Adds a deprecation notice to the README using GitHub's `[!CAUTION]` admonition, directing users to the new [`exploreomni/omni-agent-skills`](https://github.com/exploreomni/omni-agent-skills) repository
- Includes migration instructions for both CLI and team deployment (`.claude/settings.json`) workflows
- Preserves the original README content below the notice for reference

## Post-merge steps

After merging this PR:
1. **Archive the repository** via Settings > Danger Zone > Archive this repository
2. **Update the repo description** to note it is deprecated and point to `exploreomni/omni-agent-skills`
3. **Add `deprecated` and `archived` topics** to the repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)